### PR TITLE
fix math.h  BUG

### DIFF
--- a/compilers/c.php
+++ b/compilers/c.php
@@ -7,8 +7,8 @@
 	$filename_in="input.txt";
 	$filename_error="error.txt";
 	$executable="a.out";
-	$command=$CC." -lm ".$filename_code;	
-	$command_error=$command." 2>".$filename_error;
+	$command=$CC." ".$filename_code;	
+	$command_error=$command." 2>".$filename_error." -lm";
 	$check=0;
 
 	//if(trim($code)=="")


### PR DESCRIPTION
fix the problem of sqrt from math.h causes linker error “undefined reference to sqrt” only when the argument is not a constant